### PR TITLE
Add wayland permission

### DIFF
--- a/net.veloren.veloren.yaml
+++ b/net.veloren.veloren.yaml
@@ -12,6 +12,7 @@ finish-args:
   - --share=network
   - --socket=pulseaudio
   - --socket=x11
+  - --socket=wayland
 build-options:
   append-path: /usr/lib/sdk/rust-nightly/bin
   env:


### PR DESCRIPTION
The latest build that the Veloren flatpak uses has the fixes in place in place for game crashes that were happening under Wayland:

https://gitlab.com/veloren/veloren/-/issues/855

I believe it should be safe enough to enough to enable the Wayland permission.