### PR TITLE
Disable aarch64 build

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
+  "skip-arches": ["aarch64"],
   "publish-delay-hours": 0
 }


### PR DESCRIPTION
Failing aarch64 build prevents x86_64 build from updating. Sadly we can't reliably fix it with a patch due to automated updates, so disabling aarch64 build (until it's fixed upstream) is the only option.