### PR TITLE
Changed cargo build commands to build veloren-voxygen using the default-publish feature

### DIFF
--- a/net.veloren.veloren.yaml
+++ b/net.veloren.veloren.yaml
@@ -53,9 +53,8 @@ modules:
       # * Purpose of this to test local builds. Comment for Flathub build.
       #- sed -i 's/opt-level = 3/opt-level = 0/' Cargo.toml
       #- sed -i 's/opt-level = 2/opt-level = 0/g' Cargo.toml
-
       - cargo --offline fetch --manifest-path Cargo.toml
-      - cargo --offline build --release
+      - cargo --offline build --release --no-default-features --features="default-publish"
       - install -D -m 755 ./target/release/veloren-{voxygen,server-cli} -t /app/bin/
     post-install:
       # Install assets


### PR DESCRIPTION
We have recently [completed an MR](https://gitlab.com/veloren/veloren/-/merge_requests/2504) in the Veloren repository that introduces a new `default-publish` cargo feature for the `veloren-voxygen` crate that should be used by distributions of the game. This PR changes the Flatpak to use this feature.

I'm not familiar with Flatpak so if this could be tested on my behalf that would be much appreciated.