### PR TITLE
Re-enable aarch64 builds

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,3 @@
 {
-  "skip-arches": ["aarch64"],
   "publish-delay-hours": 0
 }


### PR DESCRIPTION
Attempt at seeing if aarch64 builds now succeed CI (and at investigating what the issue could be if not).

Fixes #39