### PR TITLE
Track toolchain matching exact source commit

### DIFF
--- a/net.veloren.veloren.yaml
+++ b/net.veloren.veloren.yaml
@@ -27,7 +27,8 @@ modules:
         sha256: 007f37b08b7b9f2d261c0420f7629165d2945d450cfd0f1ec2bd5dcb1ab68573
         x-checker-data:
           type: html
-          url: https://gitlab.com/veloren/veloren/-/raw/master/rust-toolchain
+          parent-id: veloren-git-0
+          url: https://gitlab.com/veloren/veloren/-/raw/$parent_commit/rust-toolchain
           version-pattern: nightly-(\d\d\d\d-\d\d-\d\d)
           url-template: https://static.rust-lang.org/dist/$version/rust-nightly-x86_64-unknown-linux-gnu.tar.xz
 
@@ -37,7 +38,8 @@ modules:
         sha256: 1f5418a8eb34d3884a029fe762a8547a9b4368276c89059e0372ea108a8a7dc9
         x-checker-data:
           type: html
-          url: https://gitlab.com/veloren/veloren/-/raw/master/rust-toolchain
+          parent-id: veloren-git-0
+          url: https://gitlab.com/veloren/veloren/-/raw/$parent_commit/rust-toolchain
           version-pattern: nightly-(\d\d\d\d-\d\d-\d\d)
           url-template: https://static.rust-lang.org/dist/$version/rust-nightly-aarch64-unknown-linux-gnu.tar.xz
 


### PR DESCRIPTION
This is a small improvement to make f-e-d-c updates more consistent, tying toolchain version to the app commit.